### PR TITLE
protobuf-lite: Update namespace

### DIFF
--- a/src/init.h
+++ b/src/init.h
@@ -43,7 +43,7 @@ inline void ParseCommandLineFlags(const char *usage, int *argc, char ***argv,
 }
 
 inline void ShutdownLibrary() {
-  google::protobuf::ShutdownProtobufLibrary();
+  google_::protobuf::ShutdownProtobufLibrary();
 #ifdef HAS_ABSL_CLEANUP_FLAGS
   absl::CleanupFlags();
 #endif

--- a/third_party/protobuf-lite/arena.cc
+++ b/third_party/protobuf-lite/arena.cc
@@ -45,7 +45,7 @@
 static const size_t kMinCleanupListElements = 8;
 static const size_t kMaxCleanupListElements = 64;  // 1kB on 64-bit.
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 PROTOBUF_EXPORT /*static*/ void* (*const ArenaOptions::kDefaultBlockAlloc)(
@@ -446,4 +446,4 @@ void* Arena::AllocateAlignedNoHook(size_t n) {
 }
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/arenastring.cc
+++ b/third_party/protobuf-lite/arenastring.cc
@@ -43,7 +43,7 @@
 #include <google/protobuf/port_def.inc>
 // clang-format on
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -63,7 +63,7 @@ const std::string& LazyString::Init() const {
 
 
 void ArenaStringPtr::Set(const std::string* default_value,
-                         ConstStringParam value, ::google::protobuf::Arena* arena) {
+                         ConstStringParam value, ::google_::protobuf::Arena* arena) {
   if (IsDefault(default_value)) {
     tagged_ptr_.Set(Arena::Create<std::string>(arena, value));
   } else {
@@ -72,7 +72,7 @@ void ArenaStringPtr::Set(const std::string* default_value,
 }
 
 void ArenaStringPtr::Set(const std::string* default_value, std::string&& value,
-                         ::google::protobuf::Arena* arena) {
+                         ::google_::protobuf::Arena* arena) {
   if (IsDefault(default_value)) {
     if (arena == nullptr) {
       tagged_ptr_.Set(new std::string(std::move(value)));
@@ -90,26 +90,26 @@ void ArenaStringPtr::Set(const std::string* default_value, std::string&& value,
 }
 
 void ArenaStringPtr::Set(EmptyDefault, ConstStringParam value,
-                         ::google::protobuf::Arena* arena) {
+                         ::google_::protobuf::Arena* arena) {
   Set(&GetEmptyStringAlreadyInited(), value, arena);
 }
 
 void ArenaStringPtr::Set(EmptyDefault, std::string&& value,
-                         ::google::protobuf::Arena* arena) {
+                         ::google_::protobuf::Arena* arena) {
   Set(&GetEmptyStringAlreadyInited(), std::move(value), arena);
 }
 
 void ArenaStringPtr::Set(NonEmptyDefault, ConstStringParam value,
-                         ::google::protobuf::Arena* arena) {
+                         ::google_::protobuf::Arena* arena) {
   Set(nullptr, value, arena);
 }
 
 void ArenaStringPtr::Set(NonEmptyDefault, std::string&& value,
-                         ::google::protobuf::Arena* arena) {
+                         ::google_::protobuf::Arena* arena) {
   Set(nullptr, std::move(value), arena);
 }
 
-std::string* ArenaStringPtr::Mutable(EmptyDefault, ::google::protobuf::Arena* arena) {
+std::string* ArenaStringPtr::Mutable(EmptyDefault, ::google_::protobuf::Arena* arena) {
   if (!IsDonatedString() && !IsDefault(&GetEmptyStringAlreadyInited())) {
     return UnsafeMutablePointer();
   } else {
@@ -118,7 +118,7 @@ std::string* ArenaStringPtr::Mutable(EmptyDefault, ::google::protobuf::Arena* ar
 }
 
 std::string* ArenaStringPtr::Mutable(const LazyString& default_value,
-                                     ::google::protobuf::Arena* arena) {
+                                     ::google_::protobuf::Arena* arena) {
   if (!IsDonatedString() && !IsDefault(nullptr)) {
     return UnsafeMutablePointer();
   } else {
@@ -127,7 +127,7 @@ std::string* ArenaStringPtr::Mutable(const LazyString& default_value,
 }
 
 std::string* ArenaStringPtr::MutableNoCopy(const std::string* default_value,
-                                           ::google::protobuf::Arena* arena) {
+                                           ::google_::protobuf::Arena* arena) {
   if (!IsDonatedString() && !IsDefault(default_value)) {
     return UnsafeMutablePointer();
   } else {
@@ -140,7 +140,7 @@ std::string* ArenaStringPtr::MutableNoCopy(const std::string* default_value,
 }
 
 template <typename... Lazy>
-std::string* ArenaStringPtr::MutableSlow(::google::protobuf::Arena* arena,
+std::string* ArenaStringPtr::MutableSlow(::google_::protobuf::Arena* arena,
                                          const Lazy&... lazy_default) {
   const std::string* const default_value =
       sizeof...(Lazy) == 0 ? &GetEmptyStringAlreadyInited() : nullptr;
@@ -152,7 +152,7 @@ std::string* ArenaStringPtr::MutableSlow(::google::protobuf::Arena* arena,
 }
 
 std::string* ArenaStringPtr::Release(const std::string* default_value,
-                                     ::google::protobuf::Arena* arena) {
+                                     ::google_::protobuf::Arena* arena) {
   if (IsDefault(default_value)) {
     return nullptr;
   } else {
@@ -161,7 +161,7 @@ std::string* ArenaStringPtr::Release(const std::string* default_value,
 }
 
 std::string* ArenaStringPtr::ReleaseNonDefault(const std::string* default_value,
-                                               ::google::protobuf::Arena* arena) {
+                                               ::google_::protobuf::Arena* arena) {
   GOOGLE_DCHECK(!IsDefault(default_value));
 
   if (!IsDonatedString()) {
@@ -183,7 +183,7 @@ std::string* ArenaStringPtr::ReleaseNonDefault(const std::string* default_value,
 }
 
 void ArenaStringPtr::SetAllocated(const std::string* default_value,
-                                  std::string* value, ::google::protobuf::Arena* arena) {
+                                  std::string* value, ::google_::protobuf::Arena* arena) {
   // Release what we have first.
   if (arena == nullptr && !IsDefault(default_value)) {
     delete UnsafeMutablePointer();
@@ -208,7 +208,7 @@ void ArenaStringPtr::SetAllocated(const std::string* default_value,
 }
 
 void ArenaStringPtr::Destroy(const std::string* default_value,
-                             ::google::protobuf::Arena* arena) {
+                             ::google_::protobuf::Arena* arena) {
   if (arena == nullptr) {
     GOOGLE_DCHECK(!IsDonatedString());
     if (!IsDefault(default_value)) {
@@ -217,11 +217,11 @@ void ArenaStringPtr::Destroy(const std::string* default_value,
   }
 }
 
-void ArenaStringPtr::Destroy(EmptyDefault, ::google::protobuf::Arena* arena) {
+void ArenaStringPtr::Destroy(EmptyDefault, ::google_::protobuf::Arena* arena) {
   Destroy(&GetEmptyStringAlreadyInited(), arena);
 }
 
-void ArenaStringPtr::Destroy(NonEmptyDefault, ::google::protobuf::Arena* arena) {
+void ArenaStringPtr::Destroy(NonEmptyDefault, ::google_::protobuf::Arena* arena) {
   Destroy(nullptr, arena);
 }
 
@@ -239,7 +239,7 @@ void ArenaStringPtr::ClearToEmpty() {
 }
 
 void ArenaStringPtr::ClearToDefault(const LazyString& default_value,
-                                    ::google::protobuf::Arena* arena) {
+                                    ::google_::protobuf::Arena* arena) {
   (void)arena;
   if (IsDefault(nullptr)) {
     // Already set to default -- do nothing.
@@ -251,4 +251,4 @@ void ArenaStringPtr::ClearToDefault(const LazyString& default_value,
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/bytestream.cc
+++ b/third_party/protobuf-lite/bytestream.cc
@@ -35,7 +35,7 @@
 
 #include <google/protobuf/stubs/logging.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace strings {
 
@@ -195,4 +195,4 @@ void LimitByteSource::CopyTo(ByteSink *sink, size_t n) {
 
 }  // namespace strings
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/coded_stream.cc
+++ b/third_party/protobuf-lite/coded_stream.cc
@@ -56,7 +56,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace io {
 
@@ -953,4 +953,4 @@ uint8* CodedOutputStream::WriteStringWithSizeToArray(const std::string& str,
 
 }  // namespace io
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/common.cc
+++ b/third_party/protobuf-lite/common.cc
@@ -63,7 +63,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 namespace internal {
@@ -326,4 +326,4 @@ const char* FatalException::what() const throw() {
 #endif
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/extension_set.cc
+++ b/third_party/protobuf-lite/extension_set.cc
@@ -50,7 +50,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -2140,4 +2140,4 @@ size_t ExtensionSet::MessageSetByteSize() const {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/generated_enum_util.cc
+++ b/third_party/protobuf-lite/generated_enum_util.cc
@@ -34,7 +34,7 @@
 
 #include <google/protobuf/generated_message_util.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 namespace {
@@ -92,4 +92,4 @@ bool InitializeEnumStrings(
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/generated_message_table_driven_lite.cc
+++ b/third_party/protobuf-lite/generated_message_table_driven_lite.cc
@@ -37,7 +37,7 @@
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/wire_format_lite.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -103,4 +103,4 @@ bool MergePartialFromCodedStreamLite(MessageLite* msg, const ParseTable& table,
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/generated_message_util.cc
+++ b/third_party/protobuf-lite/generated_message_util.cc
@@ -57,7 +57,7 @@
 #include <google/protobuf/wire_format_lite.h>
 
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -801,4 +801,4 @@ void InitSCCImpl(SCCInfoBase* scc) {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/google/protobuf/any.h
+++ b/third_party/protobuf-lite/google/protobuf/any.h
@@ -39,7 +39,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 class FieldDescriptor;
@@ -54,7 +54,7 @@ extern const char kTypeGoogleProdComPrefix[];  // "type.googleprod.com/".
 std::string GetTypeUrl(StringPiece message_name,
                        StringPiece type_url_prefix);
 
-// Helper class used to implement google::protobuf::Any.
+// Helper class used to implement google_::protobuf::Any.
 class PROTOBUF_EXPORT AnyMetadata {
   typedef ArenaStringPtr UrlType;
   typedef ArenaStringPtr ValueType;
@@ -124,7 +124,7 @@ class PROTOBUF_EXPORT AnyMetadata {
 // in the type url separating the full type name.
 //
 // NOTE: this function is available publicly as:
-//   google::protobuf::Any()  // static method on the generated message type.
+//   google_::protobuf::Any()  // static method on the generated message type.
 bool ParseAnyTypeUrl(StringPiece type_url, std::string* full_type_name);
 
 // Get the proto type name and prefix from Any::type_url value. For example,
@@ -143,7 +143,7 @@ bool GetAnyFieldDescriptors(const Message& message,
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/arena.h
+++ b/third_party/protobuf-lite/google/protobuf/arena.h
@@ -61,15 +61,15 @@ using type_info = ::type_info;
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 struct ArenaOptions;  // defined below
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 class Arena;    // defined below
@@ -687,7 +687,7 @@ class PROTOBUF_EXPORT PROTOBUF_ALIGNAS(8) Arena final {
 #undef RTTI_TYPE_ID
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/arena_impl.h
+++ b/third_party/protobuf-lite/google/protobuf/arena_impl.h
@@ -46,7 +46,7 @@
 #include <google/protobuf/port_def.inc>
 
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 struct ArenaOptions;
@@ -484,7 +484,7 @@ class PROTOBUF_EXPORT ArenaImpl {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/arenastring.h
+++ b/third_party/protobuf-lite/google/protobuf/arenastring.h
@@ -47,7 +47,7 @@
 #endif
 
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -182,13 +182,13 @@ struct PROTOBUF_EXPORT ArenaStringPtr {
   struct NonEmptyDefault {};
 
   void Set(const std::string* default_value, ConstStringParam value,
-           ::google::protobuf::Arena* arena);
+           ::google_::protobuf::Arena* arena);
   void Set(const std::string* default_value, std::string&& value,
-           ::google::protobuf::Arena* arena);
-  void Set(EmptyDefault, ConstStringParam value, ::google::protobuf::Arena* arena);
-  void Set(EmptyDefault, std::string&& value, ::google::protobuf::Arena* arena);
-  void Set(NonEmptyDefault, ConstStringParam value, ::google::protobuf::Arena* arena);
-  void Set(NonEmptyDefault, std::string&& value, ::google::protobuf::Arena* arena);
+           ::google_::protobuf::Arena* arena);
+  void Set(EmptyDefault, ConstStringParam value, ::google_::protobuf::Arena* arena);
+  void Set(EmptyDefault, std::string&& value, ::google_::protobuf::Arena* arena);
+  void Set(NonEmptyDefault, ConstStringParam value, ::google_::protobuf::Arena* arena);
+  void Set(NonEmptyDefault, std::string&& value, ::google_::protobuf::Arena* arena);
 
   // Basic accessors.
   const std::string& Get() const PROTOBUF_ALWAYS_INLINE {
@@ -201,24 +201,24 @@ struct PROTOBUF_EXPORT ArenaStringPtr {
   }
 
   // For fields with an empty default value.
-  std::string* Mutable(EmptyDefault, ::google::protobuf::Arena* arena);
+  std::string* Mutable(EmptyDefault, ::google_::protobuf::Arena* arena);
   // For fields with a non-empty default value.
-  std::string* Mutable(const LazyString& default_value, ::google::protobuf::Arena* arena);
+  std::string* Mutable(const LazyString& default_value, ::google_::protobuf::Arena* arena);
 
   // Release returns a std::string* instance that is heap-allocated and is not
   // Own()'d by any arena. If the field is not set, this returns NULL. The
   // caller retains ownership. Clears this field back to NULL state. Used to
   // implement release_<field>() methods on generated classes.
   std::string* Release(const std::string* default_value,
-                       ::google::protobuf::Arena* arena);
+                       ::google_::protobuf::Arena* arena);
   std::string* ReleaseNonDefault(const std::string* default_value,
-                                 ::google::protobuf::Arena* arena);
+                                 ::google_::protobuf::Arena* arena);
 
   // Takes a std::string that is heap-allocated, and takes ownership. The
   // std::string's destructor is registered with the arena. Used to implement
   // set_allocated_<field> in generated classes.
   void SetAllocated(const std::string* default_value, std::string* value,
-                    ::google::protobuf::Arena* arena);
+                    ::google_::protobuf::Arena* arena);
 
   // Swaps internal pointers. Arena-safety semantics: this is guarded by the
   // logic in Swap()/UnsafeArenaSwap() at the message level, so this method is
@@ -227,9 +227,9 @@ struct PROTOBUF_EXPORT ArenaStringPtr {
                    Arena* arena) PROTOBUF_ALWAYS_INLINE;
 
   // Frees storage (if not on an arena).
-  void Destroy(const std::string* default_value, ::google::protobuf::Arena* arena);
-  void Destroy(EmptyDefault, ::google::protobuf::Arena* arena);
-  void Destroy(NonEmptyDefault, ::google::protobuf::Arena* arena);
+  void Destroy(const std::string* default_value, ::google_::protobuf::Arena* arena);
+  void Destroy(EmptyDefault, ::google_::protobuf::Arena* arena);
+  void Destroy(NonEmptyDefault, ::google_::protobuf::Arena* arena);
 
   // Clears content, but keeps allocated std::string, to avoid the overhead of
   // heap operations. After this returns, the content (as seen by the user) will
@@ -244,7 +244,7 @@ struct PROTOBUF_EXPORT ArenaStringPtr {
   // Clears content, but keeps allocated std::string if arena != NULL, to avoid
   // the overhead of heap operations. After this returns, the content (as seen
   // by the user) will always be equal to |default_value|.
-  void ClearToDefault(const LazyString& default_value, ::google::protobuf::Arena* arena);
+  void ClearToDefault(const LazyString& default_value, ::google_::protobuf::Arena* arena);
 
   // Called from generated code / reflection runtime only. Resets value to point
   // to a default string pointer, with the semantics that this
@@ -261,7 +261,7 @@ struct PROTOBUF_EXPORT ArenaStringPtr {
   // Similar to `MutableNoArenaNoDefault`, but also handles the arena case.
   // If the value was donated, the contents are discarded.
   std::string* MutableNoCopy(const std::string* default_value,
-                             ::google::protobuf::Arena* arena);
+                             ::google_::protobuf::Arena* arena);
 
   // Destroy the string. Assumes `arena == nullptr`.
   void DestroyNoArena(const std::string* default_value);
@@ -294,7 +294,7 @@ struct PROTOBUF_EXPORT ArenaStringPtr {
   // MutableSlow requires that !IsString() || IsDefault
   // Variadic to support 0 args for EmptyDefault and 1 arg for LazyString.
   template <typename... Lazy>
-  std::string* MutableSlow(::google::protobuf::Arena* arena, const Lazy&... lazy_default);
+  std::string* MutableSlow(::google_::protobuf::Arena* arena, const Lazy&... lazy_default);
 
 };
 
@@ -368,7 +368,7 @@ inline std::string* ArenaStringPtr::UnsafeMutablePointer() {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/descriptor.h
+++ b/third_party/protobuf-lite/google/protobuf/descriptor.h
@@ -77,7 +77,7 @@
 #endif
 
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 // Defined in this file.
@@ -2317,7 +2317,7 @@ inline const FieldDescriptor* OneofDescriptor::field(int index) const {
 }
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/extension_set.h
+++ b/third_party/protobuf-lite/google/protobuf/extension_set.h
@@ -59,7 +59,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 class Arena;
 class Descriptor;       // descriptor.h
@@ -73,9 +73,9 @@ namespace internal {
 class FieldSkipper;  // wire_format_lite.h
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -1295,7 +1295,7 @@ class RepeatedMessageTypeTraits {
     // See notes above in RepeatedEnumTypeTraits::GetRepeated(): same
     // casting hack applies here, because a RepeatedPtrField<MessageLite>
     // cannot naturally become a RepeatedPtrType<Type> even though Type is
-    // presumably a message. google::protobuf::Message goes through similar contortions
+    // presumably a message. google_::protobuf::Message goes through similar contortions
     // with a reinterpret_cast<>.
     return *reinterpret_cast<const RepeatedPtrField<Type>*>(
         set.GetRawRepeatedField(number, GetDefaultRepeatedField()));
@@ -1556,7 +1556,7 @@ class ExtensionIdentifier {
 // Call this function to ensure that this extensions's reflection is linked into
 // the binary:
 //
-//   google::protobuf::LinkExtensionReflection(Foo::my_extension);
+//   google_::protobuf::LinkExtensionReflection(Foo::my_extension);
 //
 // This will ensure that the following lookup will succeed:
 //
@@ -1578,13 +1578,13 @@ class ExtensionIdentifier {
 template <typename ExtendeeType, typename TypeTraitsType,
           internal::FieldType field_type, bool is_packed>
 void LinkExtensionReflection(
-    const google::protobuf::internal::ExtensionIdentifier<
+    const google_::protobuf::internal::ExtensionIdentifier<
         ExtendeeType, TypeTraitsType, field_type, is_packed>& extension) {
   internal::StrongReference(extension);
 }
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/extension_set_inl.h
+++ b/third_party/protobuf-lite/google/protobuf/extension_set_inl.h
@@ -35,7 +35,7 @@
 #include <google/protobuf/extension_set.h>
 #include <google/protobuf/metadata_lite.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -271,6 +271,6 @@ const char* ExtensionSet::ParseMessageSetItemTmpl(
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #endif  // GOOGLE_PROTOBUF_EXTENSION_SET_INL_H__

--- a/third_party/protobuf-lite/google/protobuf/generated_enum_reflection.h
+++ b/third_party/protobuf-lite/google/protobuf/generated_enum_reflection.h
@@ -51,13 +51,13 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 class EnumDescriptor;
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 // Returns the EnumDescriptor for enum type E, which must be a
@@ -91,7 +91,7 @@ PROTOBUF_EXPORT const std::string& NameOfEnum(const EnumDescriptor* descriptor,
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/generated_enum_util.h
+++ b/third_party/protobuf-lite/google/protobuf/generated_enum_util.h
@@ -42,7 +42,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 // This type trait can be used to cause templates to only match proto2 enum
@@ -76,7 +76,7 @@ PROTOBUF_EXPORT bool InitializeEnumStrings(
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/generated_message_table_driven.h
+++ b/third_party/protobuf-lite/google/protobuf/generated_message_table_driven.h
@@ -53,7 +53,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -329,7 +329,7 @@ void MapFieldSerializer(const uint8* base, uint32 offset, uint32 tag,
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/generated_message_table_driven_lite.h
+++ b/third_party/protobuf-lite/google/protobuf/generated_message_table_driven_lite.h
@@ -42,7 +42,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -795,7 +795,7 @@ bool MergePartialFromCodedStreamImpl(MessageLite* msg, const ParseTable& table,
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/generated_message_util.h
+++ b/third_party/protobuf-lite/google/protobuf/generated_message_util.h
@@ -63,7 +63,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 class Arena;
@@ -263,7 +263,7 @@ inline void OnShutdownDestroyString(const std::string* ptr) {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/has_bits.h
+++ b/third_party/protobuf-lite/google/protobuf/has_bits.h
@@ -40,7 +40,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -109,7 +109,7 @@ inline bool HasBits<doublewords>::empty() const {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/implicit_weak_message.h
+++ b/third_party/protobuf-lite/google/protobuf/implicit_weak_message.h
@@ -47,7 +47,7 @@
 // This file is logically internal-only and should only be used by protobuf
 // generated code.
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -183,7 +183,7 @@ struct WeakRepeatedPtrField {
 };
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/io/coded_stream.h
+++ b/third_party/protobuf-lite/google/protobuf/io/coded_stream.h
@@ -147,7 +147,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 class DescriptorPool;
@@ -639,8 +639,8 @@ class PROTOBUF_EXPORT CodedInputStream {
 
   static int default_recursion_limit_;  // 100 by default.
 
-  friend class google::protobuf::ZeroCopyCodedInputStream;
-  friend class google::protobuf::internal::EpsCopyByteStream;
+  friend class google_::protobuf::ZeroCopyCodedInputStream;
+  friend class google_::protobuf::internal::EpsCopyByteStream;
 };
 
 // EpsCopyOutputStream wraps a ZeroCopyOutputStream and exposes a new stream,
@@ -1703,7 +1703,7 @@ inline uint8* CodedOutputStream::WriteStringToArray(const std::string& str,
 
 }  // namespace io
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #if defined(_MSC_VER) && _MSC_VER >= 1300 && !defined(__INTEL_COMPILER)
 #pragma runtime_checks("c", restore)

--- a/third_party/protobuf-lite/google/protobuf/io/io_win32.h
+++ b/third_party/protobuf-lite/google/protobuf/io/io_win32.h
@@ -37,7 +37,7 @@
 // as macro definitions for flags of these functions.
 //
 // By including this file you'll redefine open/access/etc. to
-// ::google::protobuf::io::win32::{open/access/etc.}.
+// ::google_::protobuf::io::win32::{open/access/etc.}.
 // Make sure you don't include a header that attempts to redeclare or
 // redefine these functions, that'll lead to confusing compilation
 // errors. It's best to #include this file as the last one to ensure that.
@@ -57,7 +57,7 @@
 
 // Compilers on Windows other than MSVC (e.g. Cygwin, MinGW32) define the
 // following functions already, except for mkdir.
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace io {
 namespace win32 {
@@ -114,7 +114,7 @@ PROTOBUF_EXPORT bool wcs_to_utf8(const wchar_t* input, std::string* out);
 }  // namespace win32
 }  // namespace io
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #ifndef W_OK
 #define W_OK 02  // not defined by MSVC for whatever reason

--- a/third_party/protobuf-lite/google/protobuf/io/zero_copy_stream.h
+++ b/third_party/protobuf-lite/google/protobuf/io/zero_copy_stream.h
@@ -114,7 +114,7 @@
 #include <google/protobuf/port_def.inc>
 
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace io {
 
@@ -246,7 +246,7 @@ class PROTOBUF_EXPORT ZeroCopyOutputStream {
 
 }  // namespace io
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/io/zero_copy_stream_impl.h
+++ b/third_party/protobuf-lite/google/protobuf/io/zero_copy_stream_impl.h
@@ -50,7 +50,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace io {
 
@@ -320,7 +320,7 @@ class PROTOBUF_EXPORT ConcatenatingInputStream : public ZeroCopyInputStream {
 
 }  // namespace io
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/io/zero_copy_stream_impl_lite.h
+++ b/third_party/protobuf-lite/google/protobuf/io/zero_copy_stream_impl_lite.h
@@ -57,7 +57,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace io {
 
@@ -401,7 +401,7 @@ inline std::pair<char*, bool> as_string_data(std::string* s) {
 
 }  // namespace io
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/map.h
+++ b/third_party/protobuf-lite/google/protobuf/map.h
@@ -62,7 +62,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 template <typename Key, typename T>
@@ -1355,7 +1355,7 @@ class Map {
 };
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/map_entry_lite.h
+++ b/third_party/protobuf-lite/google/protobuf/map_entry_lite.h
@@ -50,7 +50,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 template <typename Derived, typename Key, typename Value,
@@ -63,9 +63,9 @@ template <typename Derived, typename Key, typename Value,
 class MapFieldLite;
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -223,7 +223,7 @@ class MapEntryImpl : public Base {
   std::string GetTypeName() const override { return ""; }
 
   void CheckTypeAndMergeFrom(const MessageLite& other) override {
-    MergeFromInternal(*::google::protobuf::internal::DownCast<const Derived*>(&other));
+    MergeFromInternal(*::google_::protobuf::internal::DownCast<const Derived*>(&other));
   }
 
   const char* _InternalParse(const char* ptr, ParseContext* ctx) final {
@@ -262,7 +262,7 @@ class MapEntryImpl : public Base {
     return size;
   }
 
-  ::google::protobuf::uint8* _InternalSerialize(::google::protobuf::uint8* ptr,
+  ::google_::protobuf::uint8* _InternalSerialize(::google_::protobuf::uint8* ptr,
                               io::EpsCopyOutputStream* stream) const override {
     ptr = KeyTypeHandler::Write(kKeyFieldNumber, key(), ptr, stream);
     return ValueTypeHandler::Write(kValueFieldNumber, value(), ptr, stream);
@@ -646,7 +646,7 @@ struct MapEntryHelper<
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/map_field_lite.h
+++ b/third_party/protobuf-lite/google/protobuf/map_field_lite.h
@@ -45,7 +45,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -176,7 +176,7 @@ struct MapEntryToMapField<
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/map_type_handler.h
+++ b/third_party/protobuf-lite/google/protobuf/map_type_handler.h
@@ -40,7 +40,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -683,6 +683,6 @@ PRIMITIVE_HANDLER_FUNCTIONS(BOOL)
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #endif  // GOOGLE_PROTOBUF_TYPE_HANDLER_H__

--- a/third_party/protobuf-lite/google/protobuf/message_lite.h
+++ b/third_party/protobuf-lite/google/protobuf/message_lite.h
@@ -58,7 +58,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 template <typename T>
@@ -333,7 +333,7 @@ class PROTOBUF_EXPORT MessageLite {
   // This function takes a string in the (non-human-readable) binary wire
   // format, matching the encoding output by MessageLite::SerializeToString().
   // If you'd like to convert a human-readable string into a protocol buffer
-  // object, see google::protobuf::TextFormat::ParseFromString().
+  // object, see google_::protobuf::TextFormat::ParseFromString().
   PROTOBUF_ATTRIBUTE_REINITIALIZES bool ParseFromString(ConstStringParam data);
   // Like ParseFromString(), but accepts messages that are missing
   // required fields.
@@ -614,7 +614,7 @@ T* OnShutdownDelete(T* p) {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/metadata_lite.h
+++ b/third_party/protobuf-lite/google/protobuf/metadata_lite.h
@@ -42,7 +42,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -241,7 +241,7 @@ class PROTOBUF_EXPORT LiteUnknownFieldSetter {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/parse_context.h
+++ b/third_party/protobuf-lite/google/protobuf/parse_context.h
@@ -49,7 +49,7 @@
 #include <google/protobuf/port_def.inc>
 
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 class UnknownFieldSet;
@@ -862,7 +862,7 @@ PROTOBUF_EXPORT PROTOBUF_MUST_USE_RESULT const char* UnknownFieldParse(
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/port_def.inc
+++ b/third_party/protobuf-lite/google/protobuf/port_def.inc
@@ -156,14 +156,14 @@
 #endif
 
 
-#define PROTOBUF_NAMESPACE "google::protobuf"
-#define PROTOBUF_NAMESPACE_ID google::protobuf
+#define PROTOBUF_NAMESPACE "google_::protobuf"
+#define PROTOBUF_NAMESPACE_ID google_::protobuf
 #define PROTOBUF_NAMESPACE_OPEN \
-  namespace google {            \
+  namespace google_ {            \
   namespace protobuf {
 #define PROTOBUF_NAMESPACE_CLOSE \
   } /* namespace protobuf */     \
-  } /* namespace google */
+  } /* namespace google_ */
 
 #if defined(__GNUC__) || defined(__clang__)
 #define PROTOBUF_DEPRECATED __attribute__((deprecated))
@@ -368,7 +368,7 @@
 // choose 16 rather than some other number just in case the compiler would
 // be confused by an unaligned pointer.
 #define PROTOBUF_FIELD_OFFSET(TYPE, FIELD)                                \
-  static_cast< ::google::protobuf::uint32>(reinterpret_cast<const char*>(                   \
+  static_cast< ::google_::protobuf::uint32>(reinterpret_cast<const char*>(                   \
                              &reinterpret_cast<const TYPE*>(16)->FIELD) - \
                          reinterpret_cast<const char*>(16))
 #endif

--- a/third_party/protobuf-lite/google/protobuf/repeated_field.h
+++ b/third_party/protobuf-lite/google/protobuf/repeated_field.h
@@ -73,7 +73,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 class Message;
@@ -483,7 +483,7 @@ class RepeatedField final {
   using FastAdder = FastAdderImpl<>;
 
   friend class TestRepeatedFieldHelper;
-  friend class ::google::protobuf::internal::ParseContext;
+  friend class ::google_::protobuf::internal::ParseContext;
 };
 
 namespace internal {
@@ -792,7 +792,7 @@ class PROTOBUF_EXPORT RepeatedPtrFieldBase {
   friend class MergePartialFromCodedStreamHelper;
   friend class AccessorHelper;
   template <typename T>
-  friend struct google::protobuf::WeakRepeatedPtrField;
+  friend struct google_::protobuf::WeakRepeatedPtrField;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(RepeatedPtrFieldBase);
 };
@@ -2840,7 +2840,7 @@ extern template class PROTOBUF_EXPORT_TEMPLATE_DECLARE
     RepeatedPtrField<std::string>;
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/bytestream.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/bytestream.h
@@ -60,7 +60,7 @@
 
 class CordByteSink;
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace strings {
 
@@ -344,7 +344,7 @@ class PROTOBUF_EXPORT LimitByteSource : public ByteSource {
 
 }  // namespace strings
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/callback.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/callback.h
@@ -10,7 +10,7 @@
 // ===================================================================
 // emulates google3/base/callback.h
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 // Abstract interface for a callback.  When calling an RPC, you must provide
@@ -576,7 +576,7 @@ inline ResultCallback2<R, A1, A2>* NewPermanentCallback(
 void PROTOBUF_EXPORT DoNothing();
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/casts.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/casts.h
@@ -36,7 +36,7 @@
 #include <google/protobuf/port_def.inc>
 #include <type_traits>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -132,7 +132,7 @@ using internal::down_cast;
 using internal::bit_cast;
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/common.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/common.h
@@ -73,7 +73,7 @@
 
 namespace std {}
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -115,7 +115,7 @@ std::string PROTOBUF_EXPORT VersionString(int version);
 // matches the headers you compiled against.  If a version mismatch is
 // detected, the process will abort.
 #define GOOGLE_PROTOBUF_VERIFY_VERSION                                    \
-  ::google::protobuf::internal::VerifyVersion(                            \
+  ::google_::protobuf::internal::VerifyVersion(                            \
     GOOGLE_PROTOBUF_VERSION, GOOGLE_PROTOBUF_MIN_LIBRARY_VERSION,         \
     __FILE__)
 
@@ -195,7 +195,7 @@ class FatalException : public std::exception {
 using std::string;
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/hash.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/hash.h
@@ -39,11 +39,11 @@
 #include <unordered_set>
 
 # define GOOGLE_PROTOBUF_HASH_NAMESPACE_DECLARATION_START \
-  namespace google {                                      \
+  namespace google_ {                                      \
   namespace protobuf {
 # define GOOGLE_PROTOBUF_HASH_NAMESPACE_DECLARATION_END }}
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 template <typename Key>
@@ -109,6 +109,6 @@ struct hash<std::pair<First, Second> > {
 };
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #endif  // GOOGLE_PROTOBUF_STUBS_HASH_H__

--- a/third_party/protobuf-lite/google/protobuf/stubs/int128.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/int128.h
@@ -36,7 +36,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 struct uint128_pod;
@@ -380,7 +380,7 @@ inline uint128& uint128::operator--() {
 }
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/logging.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/logging.h
@@ -39,7 +39,7 @@
 // ===================================================================
 // emulates google3/base/logging.h
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 enum LogLevel {
@@ -144,15 +144,15 @@ inline bool IsOk(bool status) { return status; }
 #undef GOOGLE_DCHECK_GE
 
 #define GOOGLE_LOG(LEVEL)                          \
-  ::google::protobuf::internal::LogFinisher() = \
-      ::google::protobuf::internal::LogMessage( \
-          ::google::protobuf::LOGLEVEL_##LEVEL, __FILE__, __LINE__)
+  ::google_::protobuf::internal::LogFinisher() = \
+      ::google_::protobuf::internal::LogMessage( \
+          ::google_::protobuf::LOGLEVEL_##LEVEL, __FILE__, __LINE__)
 #define GOOGLE_LOG_IF(LEVEL, CONDITION) \
   !(CONDITION) ? (void)0 : GOOGLE_LOG(LEVEL)
 
 #define GOOGLE_CHECK(EXPRESSION) \
   GOOGLE_LOG_IF(FATAL, !(EXPRESSION)) << "CHECK failed: " #EXPRESSION ": "
-#define GOOGLE_CHECK_OK(A) GOOGLE_CHECK(::google::protobuf::internal::IsOk(A))
+#define GOOGLE_CHECK_OK(A) GOOGLE_CHECK(::google_::protobuf::internal::IsOk(A))
 #define GOOGLE_CHECK_EQ(A, B) GOOGLE_CHECK((A) == (B))
 #define GOOGLE_CHECK_NE(A, B) GOOGLE_CHECK((A) != (B))
 #define GOOGLE_CHECK_LT(A, B) GOOGLE_CHECK((A) <  (B))
@@ -171,7 +171,7 @@ T* CheckNotNull(const char* /* file */, int /* line */,
 }
 }  // namespace internal
 #define GOOGLE_CHECK_NOTNULL(A)               \
-  ::google::protobuf::internal::CheckNotNull( \
+  ::google_::protobuf::internal::CheckNotNull( \
       __FILE__, __LINE__, "'" #A "' must not be nullptr", (A))
 
 #ifdef NDEBUG
@@ -179,7 +179,7 @@ T* CheckNotNull(const char* /* file */, int /* line */,
 #define GOOGLE_DLOG(LEVEL) GOOGLE_LOG_IF(LEVEL, false)
 
 #define GOOGLE_DCHECK(EXPRESSION) while(false) GOOGLE_CHECK(EXPRESSION)
-#define GOOGLE_DCHECK_OK(E) GOOGLE_DCHECK(::google::protobuf::internal::IsOk(E))
+#define GOOGLE_DCHECK_OK(E) GOOGLE_DCHECK(::google_::protobuf::internal::IsOk(E))
 #define GOOGLE_DCHECK_EQ(A, B) GOOGLE_DCHECK((A) == (B))
 #define GOOGLE_DCHECK_NE(A, B) GOOGLE_DCHECK((A) != (B))
 #define GOOGLE_DCHECK_LT(A, B) GOOGLE_DCHECK((A) <  (B))
@@ -234,7 +234,7 @@ class PROTOBUF_EXPORT LogSilencer {
 };
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/macros.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/macros.h
@@ -33,7 +33,7 @@
 
 #include <google/protobuf/stubs/port.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 #undef GOOGLE_DISALLOW_EVIL_CONSTRUCTORS
@@ -115,6 +115,6 @@ struct CompileAssert {
 #define GOOGLE_COMPILE_ASSERT(expr, msg) static_assert(expr, #msg)
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #endif  // GOOGLE_PROTOBUF_MACROS_H__

--- a/third_party/protobuf-lite/google/protobuf/stubs/map_util.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/map_util.h
@@ -42,7 +42,7 @@
 
 #include <google/protobuf/stubs/common.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 // Local implementation of RemoveConst to avoid including base/type_traits.h.
@@ -764,6 +764,6 @@ void AppendValuesFromMap(const MapContainer& map_container,
 }
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #endif  // GOOGLE_PROTOBUF_STUBS_MAP_UTIL_H__

--- a/third_party/protobuf-lite/google/protobuf/stubs/mutex.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/mutex.h
@@ -63,7 +63,7 @@
 
 // ===================================================================
 // emulates google3/base/mutex.h
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -176,7 +176,7 @@ using internal::WriterMutexLock;
 using internal::MutexLockMaybe;
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #undef GOOGLE_PROTOBUF_ACQUIRE
 #undef GOOGLE_PROTOBUF_RELEASE

--- a/third_party/protobuf-lite/google/protobuf/stubs/once.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/once.h
@@ -36,7 +36,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -48,7 +48,7 @@ void call_once(Args&&... args ) {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/port.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/port.h
@@ -114,7 +114,7 @@
 #error "Protobuf requires at least C++11."
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 using ConstStringParam = const std::string &;
@@ -398,7 +398,7 @@ class BigEndian {
 };
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/status.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/status.h
@@ -38,7 +38,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace util {
 namespace error {
@@ -118,7 +118,7 @@ PROTOBUF_EXPORT std::ostream& operator<<(std::ostream& os, const Status& x);
 
 }  // namespace util
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/statusor.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/statusor.h
@@ -91,7 +91,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace util {
 
@@ -265,7 +265,7 @@ inline const T& StatusOr<T>::value() const {
 }
 }  // namespace util
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/stl_util.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/stl_util.h
@@ -35,7 +35,7 @@
 
 #include <google/protobuf/stubs/common.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 // Inside Google, this function implements a horrible, disgusting hack in which
@@ -66,6 +66,6 @@ inline char* string_as_array(std::string* str) {
 }
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #endif  // GOOGLE_PROTOBUF_STUBS_STL_UTIL_H__

--- a/third_party/protobuf-lite/google/protobuf/stubs/stringpiece.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/stringpiece.h
@@ -152,7 +152,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 // StringPiece has *two* size types.
 // StringPiece::size_type
@@ -470,7 +470,7 @@ struct StringPiecePod {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 GOOGLE_PROTOBUF_HASH_NAMESPACE_DECLARATION_START
 template<> struct hash<StringPiece> {

--- a/third_party/protobuf-lite/google/protobuf/stubs/stringprintf.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/stringprintf.h
@@ -48,7 +48,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 // Return a C++ string
@@ -78,7 +78,7 @@ PROTOBUF_EXPORT extern std::string StringPrintfVector(
     const char* format, const std::vector<std::string>& v);
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/strutil.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/strutil.h
@@ -41,7 +41,7 @@
 #include <google/protobuf/port_def.inc>
 #include <vector>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 #if defined(_MSC_VER) && _MSC_VER < 1800
@@ -946,7 +946,7 @@ double NoLocaleStrtod(const char* str, char** endptr);
 }  // namespace internal
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/stubs/time.h
+++ b/third_party/protobuf-lite/google/protobuf/stubs/time.h
@@ -34,7 +34,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -73,7 +73,7 @@ bool PROTOBUF_EXPORT ParseTime(const std::string& value, int64* seconds,
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/google/protobuf/unknown_field_set.h
+++ b/third_party/protobuf-lite/google/protobuf/unknown_field_set.h
@@ -57,7 +57,7 @@
 #error "You cannot SWIG proto headers"
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 class InternalMetadata;           // metadata_lite.h
@@ -405,7 +405,7 @@ inline void UnknownField::SetType(Type type) {
 
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 #endif  // GOOGLE_PROTOBUF_UNKNOWN_FIELD_SET_H__

--- a/third_party/protobuf-lite/google/protobuf/wire_format_lite.h
+++ b/third_party/protobuf-lite/google/protobuf/wire_format_lite.h
@@ -67,7 +67,7 @@
 #undef TYPE_BOOL
 
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -1859,7 +1859,7 @@ bool ParseMessageSetItemImpl(io::CodedInputStream* input, MS ms) {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #include <google/protobuf/port_undef.inc>
 

--- a/third_party/protobuf-lite/implicit_weak_message.cc
+++ b/third_party/protobuf-lite/implicit_weak_message.cc
@@ -37,7 +37,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -62,4 +62,4 @@ const ImplicitWeakMessage* ImplicitWeakMessage::default_instance() {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/int128.cc
+++ b/third_party/protobuf-lite/int128.cc
@@ -38,7 +38,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 const uint128_pod kuint128max = {
@@ -189,4 +189,4 @@ std::ostream& operator<<(std::ostream& o, const uint128& b) {
 }
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/io_win32.cc
+++ b/third_party/protobuf-lite/io_win32.cc
@@ -71,7 +71,7 @@
 #include <string>
 #include <vector>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace io {
 namespace win32 {
@@ -465,6 +465,6 @@ bool wcs_to_utf8(const wchar_t* input, string* out) {
 }  // namespace win32
 }  // namespace io
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_
 
 #endif  // defined(_WIN32)

--- a/third_party/protobuf-lite/message_lite.cc
+++ b/third_party/protobuf-lite/message_lite.cc
@@ -57,7 +57,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 std::string MessageLite::InitializationErrorString() const {
@@ -580,4 +580,4 @@ void ShutdownProtobufLibrary() {
 
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/parse_context.cc
+++ b/third_party/protobuf-lite/parse_context.cc
@@ -41,7 +41,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -590,4 +590,4 @@ const char* UnknownFieldParse(uint32 tag, std::string* unknown, const char* ptr,
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/repeated_field.cc
+++ b/third_party/protobuf-lite/repeated_field.cc
@@ -42,7 +42,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 namespace internal {
@@ -133,4 +133,4 @@ template class PROTOBUF_EXPORT_TEMPLATE_DEFINE RepeatedField<double>;
 template class PROTOBUF_EXPORT_TEMPLATE_DEFINE RepeatedPtrField<std::string>;
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/status.cc
+++ b/third_party/protobuf-lite/status.cc
@@ -34,7 +34,7 @@
 #include <string>
 #include <utility>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace util {
 namespace error {
@@ -131,4 +131,4 @@ std::ostream& operator<<(std::ostream& os, const Status& x) {
 
 }  // namespace util
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/statusor.cc
+++ b/third_party/protobuf-lite/statusor.cc
@@ -32,7 +32,7 @@
 
 #include <google/protobuf/stubs/logging.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace util {
 namespace internal {
@@ -45,4 +45,4 @@ void StatusOrHelper::Crash(const Status& status) {
 }  // namespace internal
 }  // namespace util
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/stringpiece.cc
+++ b/third_party/protobuf-lite/stringpiece.cc
@@ -37,7 +37,7 @@
 
 #include <google/protobuf/stubs/logging.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 std::ostream& operator<<(std::ostream& o, StringPiece piece) {
   o.write(piece.data(), piece.size());
@@ -267,4 +267,4 @@ StringPiece StringPiece::substr(size_type pos, size_type n) const {
 const StringPiece::size_type StringPiece::npos = size_type(-1);
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/stringprintf.cc
+++ b/third_party/protobuf-lite/stringprintf.cc
@@ -40,7 +40,7 @@
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/logging.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 #ifdef _MSC_VER
@@ -173,4 +173,4 @@ std::string StringPrintfVector(const char* format,
                       cstr[30], cstr[31]);
 }
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/structurally_valid.cc
+++ b/third_party/protobuf-lite/structurally_valid.cc
@@ -34,7 +34,7 @@
 
 #include <google/protobuf/stubs/stringpiece.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -612,4 +612,4 @@ char* UTF8CoerceToStructurallyValid(StringPiece src_str, char* idst,
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/strutil.cc
+++ b/third_party/protobuf-lite/strutil.cc
@@ -57,7 +57,7 @@
 #define snprintf _snprintf
 #endif
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 
 // These are defined as macros on some platforms.  #undef them so that we can
@@ -2474,4 +2474,4 @@ double NoLocaleStrtod(const char *str, char **endptr) {
 }  // namespace internal
 
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/time.cc
+++ b/third_party/protobuf-lite/time.cc
@@ -5,7 +5,7 @@
 #include <google/protobuf/stubs/stringprintf.h>
 #include <google/protobuf/stubs/strutil.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -362,4 +362,4 @@ bool ParseTime(const std::string& value, int64* seconds, int32* nanos) {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/wire_format_lite.cc
+++ b/third_party/protobuf-lite/wire_format_lite.cc
@@ -48,7 +48,7 @@
 
 #include <google/protobuf/port_def.inc>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace internal {
 
@@ -775,4 +775,4 @@ size_t WireFormatLite::SInt64Size(const RepeatedField<int64>& value) {
 
 }  // namespace internal
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/zero_copy_stream.cc
+++ b/third_party/protobuf-lite/zero_copy_stream.cc
@@ -37,7 +37,7 @@
 #include <google/protobuf/stubs/logging.h>
 #include <google/protobuf/stubs/common.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace io {
 
@@ -52,4 +52,4 @@ bool ZeroCopyOutputStream::WriteAliasedRaw(const void* /* data */,
 
 }  // namespace io
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/zero_copy_stream_impl.cc
+++ b/third_party/protobuf-lite/zero_copy_stream_impl.cc
@@ -50,7 +50,7 @@
 #include <google/protobuf/stubs/stl_util.h>
 
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace io {
 
@@ -60,11 +60,11 @@ namespace io {
 #define lseek(fd, offset, origin) ((off_t)-1)
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
-using google::protobuf::io::win32::access;
-using google::protobuf::io::win32::close;
-using google::protobuf::io::win32::open;
-using google::protobuf::io::win32::read;
-using google::protobuf::io::win32::write;
+using google_::protobuf::io::win32::access;
+using google_::protobuf::io::win32::close;
+using google_::protobuf::io::win32::open;
+using google_::protobuf::io::win32::read;
+using google_::protobuf::io::win32::write;
 #endif
 
 namespace {
@@ -363,4 +363,4 @@ int64_t ConcatenatingInputStream::ByteCount() const {
 
 }  // namespace io
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_

--- a/third_party/protobuf-lite/zero_copy_stream_impl_lite.cc
+++ b/third_party/protobuf-lite/zero_copy_stream_impl_lite.cc
@@ -42,7 +42,7 @@
 #include <google/protobuf/stubs/casts.h>
 #include <google/protobuf/stubs/stl_util.h>
 
-namespace google {
+namespace google_ {
 namespace protobuf {
 namespace io {
 
@@ -464,4 +464,4 @@ int64_t LimitingInputStream::ByteCount() const {
 
 }  // namespace io
 }  // namespace protobuf
-}  // namespace google
+}  // namespace google_


### PR DESCRIPTION
Change namespace so as not to interfere with other libraries using the same library.